### PR TITLE
避免文字超出PaoMaView的范围

### DIFF
--- a/WQLPaoMaView.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/WQLPaoMaView.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/WQLPaoMaView/WQLPaoMaView.m
+++ b/WQLPaoMaView/WQLPaoMaView.m
@@ -44,6 +44,8 @@ static const NSInteger animationDuration = 15;
         CGFloat viewHeight = frame.size.height;
         labelHeight = viewHeight;
 
+        UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
+        [self addSubview:scrollView];
         
         UILabel *myLable = [[UILabel alloc]init];
         myLable.text = title;
@@ -59,7 +61,7 @@ static const NSInteger animationDuration = 15;
         
         myLable.frame = currentFrame;
         
-        [self addSubview:myLable];
+        [scrollView addSubview:myLable];
         
         labelArray  = [NSMutableArray arrayWithObject:myLable];
         
@@ -71,7 +73,7 @@ static const NSInteger animationDuration = 15;
             behindLabel.font = [UIFont systemFontOfSize:16.0f];
             behindLabel.backgroundColor = [UIColor orangeColor];
             [labelArray addObject:behindLabel];
-            [self addSubview:behindLabel];
+            [scrollView addSubview:behindLabel];
             
 
             [self doCustomAnimation];


### PR DESCRIPTION
跑马灯在滚动的时候，文字会超出所设置的PaoMaView的屏幕，文字的显示范围为整个屏幕的宽度，为了避免这中情况，view中的label应该以一个scrollView为父视图。所以应当再添加一个scrollView作为PaoMaView的子视图，再将label加在scrollview上，这样文字就不会超出PaoMaView的范围了。